### PR TITLE
Allow custom pattern in StreamingWorkoutEngine

### DIFF
--- a/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
+++ b/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
@@ -9,7 +9,7 @@ final class StreamingWorkoutEngine {
     private let sessionManager = SessionManager()
 
     init(exercisePattern: ExercisePattern? = nil) {
-        self.detector = ProductionRepetitionDetector()
+        self.detector = ProductionRepetitionDetector(pattern: exercisePattern)
         self.memoryManager = MemoryManager()
         self.performanceController = PerformanceController()
         detector.adaptToPerformanceLevel(.high)


### PR DESCRIPTION
## Summary
- pass an optional `ExercisePattern` to `StreamingWorkoutEngine`
- store this template inside `ProductionRepetitionDetector`
- match incoming frames against the template when accumulating confidence

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68403f361efc8332b2f8a16bfd687083