### PR TITLE
Optimize temporal sequence feature extraction

### DIFF
--- a/Sources/WorkoutCounter/PatternLearner.swift
+++ b/Sources/WorkoutCounter/PatternLearner.swift
@@ -130,11 +130,10 @@ public final class TemporalPatternLearner {
         )
     }
 
-    private static func extractSequenceFeatures(_ poses: [PoseSample]) -> [MovementFeatures] {
-        return poses.map { _ in
-            // For demo purposes reuse simple extraction
-            PatternLearner.extractFeatures(from: poses)
-        }
+    static func extractSequenceFeatures(_ poses: [PoseSample]) -> [MovementFeatures] {
+        // compute features once using the full sequence then reuse for each frame
+        let features = PatternLearner.extractFeatures(from: poses)
+        return Array(repeating: features, count: poses.count)
     }
 }
 

--- a/Tests/WorkoutCounterTests/RepetitionTests.swift
+++ b/Tests/WorkoutCounterTests/RepetitionTests.swift
@@ -255,3 +255,15 @@ func detectorPerformanceLevels() async throws {
         confidenceThreshold: 0.4
     ))
 }
+
+@Test
+func sequenceFeatureExtractionConsistency() async throws {
+    let poses = generateMockPoseData(repetitions: 1)
+    let features = TemporalPatternLearner.extractSequenceFeatures(poses)
+    let expected = PatternLearner.extractFeatures(from: poses)
+    #expect(features.count == poses.count)
+    for f in features {
+        #expect(f.movementIntensity == expected.movementIntensity)
+        #expect(f.jointVelocities["metric"] == expected.jointVelocities["metric"])
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `extractSequenceFeatures` to compute sequence features once and reuse
- expose `extractSequenceFeatures` for testing
- verify feature extraction consistency in unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684041278e4c8332acd1207fcbeca368