### PR TITLE
Add Vision pose conversion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ The tests in `Tests/WorkoutCounterTests/RepetitionTests.swift` demonstrate detec
 
 The package avoids dependencies on platform frameworks so it can compile on Linux and macOS. The public APIs use simple data types making it straightforward to integrate with an iOS app that supplies pose information from Vision.
 
+### Vision Integration
+
+When running on Apple platforms you can convert `VNHumanBodyPoseObservation` values into the pose types used by WorkoutCounter:
+
+```swift
+#if canImport(Vision)
+import Vision
+import WorkoutCounter
+
+let observation: VNHumanBodyPoseObservation = ... // provided by Vision
+let pose = PoseObservation(visionObservation: observation)
+let sample = poseSample(from: pose, at: 0)
+let features = movementFeatures(from: pose)
+#endif
+```
+
 ## Performance Characteristics
 
 The algorithms are lightweight and operate on small arrays of metrics, targeting realtime analysis (~33ms per frame) when connected to camera input. Accuracy depends on the quality of pose data and the learned patterns.

--- a/Sources/WorkoutCounter/PoseObservation.swift
+++ b/Sources/WorkoutCounter/PoseObservation.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Platform-agnostic representation of a body pose.
+public struct PoseObservation {
+    /// Supported joint identifiers.
+    public enum JointName: String {
+        case rightWrist
+        case rightShoulder
+    }
+
+    /// Location and confidence for a body joint.
+    public struct JointPoint {
+        public let x: Double
+        public let y: Double
+        public let confidence: Double
+
+        public init(x: Double, y: Double, confidence: Double) {
+            self.x = x
+            self.y = y
+            self.confidence = confidence
+        }
+    }
+
+    /// Dictionary of joints indexed by ``JointName``.
+    public var joints: [JointName: JointPoint]
+
+    public init(joints: [JointName: JointPoint]) {
+        self.joints = joints
+    }
+}
+
+#if canImport(Vision)
+import Vision
+
+public extension PoseObservation {
+    /// Creates a ``PoseObservation`` from a ``VNHumanBodyPoseObservation``.
+    init(visionObservation: VNHumanBodyPoseObservation) {
+        var mapped: [JointName: JointPoint] = [:]
+        if let wrist = try? visionObservation.recognizedPoint(.rightWrist) {
+            mapped[.rightWrist] = JointPoint(
+                x: Double(wrist.location.x),
+                y: Double(wrist.location.y),
+                confidence: Double(wrist.confidence)
+            )
+        }
+        if let shoulder = try? visionObservation.recognizedPoint(.rightShoulder) {
+            mapped[.rightShoulder] = JointPoint(
+                x: Double(shoulder.location.x),
+                y: Double(shoulder.location.y),
+                confidence: Double(shoulder.confidence)
+            )
+        }
+        self.init(joints: mapped)
+    }
+}
+#endif
+
+/// Converts a ``PoseObservation`` to a ``PoseSample`` using the vertical
+/// distance between the right shoulder and wrist as the metric.
+/// - Parameters:
+///   - observation: The pose observation to convert.
+///   - time: Timestamp for the resulting sample.
+/// - Returns: A ``PoseSample`` value.
+public func poseSample(from observation: PoseObservation, at time: TimeInterval) -> PoseSample {
+    guard let wrist = observation.joints[.rightWrist],
+          let shoulder = observation.joints[.rightShoulder] else {
+        return PoseSample(time: time, metric: 0)
+    }
+    let metric = wrist.y - shoulder.y
+    return PoseSample(time: time, metric: metric)
+}
+
+/// Extracts ``MovementFeatures`` from a ``PoseObservation`` using
+/// the average joint confidence as movement intensity.
+/// - Parameter observation: The pose observation to analyze.
+/// - Returns: ``MovementFeatures`` describing the observation.
+public func movementFeatures(from observation: PoseObservation) -> MovementFeatures {
+    let confidences = observation.joints.values.map { Float($0.confidence) }
+    let intensity = confidences.reduce(0, +) / Float(max(confidences.count, 1))
+    return MovementFeatures(jointVelocities: [:], jointAngles: [:], movementIntensity: intensity, symmetry: 1)
+}

--- a/Tests/WorkoutCounterTests/RepetitionTests.swift
+++ b/Tests/WorkoutCounterTests/RepetitionTests.swift
@@ -267,3 +267,16 @@ func sequenceFeatureExtractionConsistency() async throws {
         #expect(f.jointVelocities["metric"] == expected.jointVelocities["metric"])
     }
 }
+
+@Test
+func poseObservationConversion() async throws {
+    let observation = PoseObservation(joints: [
+        .rightWrist: .init(x: 0.0, y: 0.9, confidence: 1.0),
+        .rightShoulder: .init(x: 0.0, y: 0.5, confidence: 1.0)
+    ])
+    let sample = poseSample(from: observation, at: 0)
+    #expect(sample.metric == 0.4)
+    let features = movementFeatures(from: observation)
+    #expect(features.movementIntensity == 1)
+}
+


### PR DESCRIPTION
## Summary
- bridge `VNHumanBodyPoseObservation` data to `PoseSample` and `MovementFeatures`
- document Vision integration usage
- test conversion with mocked pose data

## Testing
- `swift test -l`

------
https://chatgpt.com/codex/tasks/task_e_684041d845548332bcf69141d1573447