### PR TITLE
Add iOS camera sample

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,19 @@ let package = Package(
         .library(
             name: "WorkoutCounter",
             targets: ["WorkoutCounter"]),
+        // Sample target for iOS camera integration
+        .library(
+            name: "WorkoutCounterCameraSample",
+            targets: ["WorkoutCounterCameraSample"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "WorkoutCounter"),
+        .target(
+            name: "WorkoutCounterCameraSample",
+            dependencies: ["WorkoutCounter"]),
         .testTarget(
             name: "WorkoutCounterTests",
             dependencies: ["WorkoutCounter"]

--- a/Sources/WorkoutCounter/PerformanceController.swift
+++ b/Sources/WorkoutCounter/PerformanceController.swift
@@ -1,22 +1,22 @@
 import Foundation
 
 /// Tracks processing performance and suggests quality levels.
-final class PerformanceController {
+public final class PerformanceController {
     private var frameTimes = CircularBuffer<TimeInterval>(capacity: 60)
     private let target: TimeInterval = 1.0 / 30.0
 
-    enum QualityLevel {
+    public enum QualityLevel {
         case high
         case medium
         case low
         case minimal
     }
 
-    func recordFrameTime(_ duration: TimeInterval) {
+    public func recordFrameTime(_ duration: TimeInterval) {
         frameTimes.append(duration)
     }
 
-    func getOptimalQuality() -> QualityLevel {
+    public func getOptimalQuality() -> QualityLevel {
         let samples = frameTimes.toArray()
         guard !samples.isEmpty else { return .high }
         let avg = samples.reduce(0, +) / Double(samples.count)

--- a/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
+++ b/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
@@ -2,28 +2,28 @@ import Foundation
 import CoreFoundation
 
 /// High level engine that coordinates streaming processing.
-final class StreamingWorkoutEngine {
+public final class StreamingWorkoutEngine {
     private let detector: ProductionRepetitionDetector
     private let memoryManager: MemoryManager
     private let performanceController: PerformanceController
     private let sessionManager = SessionManager()
 
-    init(exercisePattern: ExercisePattern? = nil) {
+    public init(exercisePattern: ExercisePattern? = nil) {
         self.detector = ProductionRepetitionDetector(pattern: exercisePattern)
         self.memoryManager = MemoryManager()
         self.performanceController = PerformanceController()
         detector.adaptToPerformanceLevel(.high)
     }
 
-    enum WorkoutUpdate {
+    public enum WorkoutUpdate {
         case frameSkipped(reason: FrameSkipReason)
         case noEvent
         case repetitionLogged(RepetitionLog)
     }
 
-  enum FrameSkipReason { case performanceOptimization }
+  public enum FrameSkipReason { case performanceOptimization }
 
-    func processFrame(_ sample: PoseSample) -> WorkoutUpdate {
+    public func processFrame(_ sample: PoseSample) -> WorkoutUpdate {
         let start = CFAbsoluteTimeGetCurrent()
 
         let quality = performanceController.getOptimalQuality()
@@ -57,7 +57,7 @@ final class StreamingWorkoutEngine {
         }
     }
 
-    func shouldProcessFrame(_ sample: PoseSample, quality: PerformanceController.QualityLevel) -> Bool {
+    public func shouldProcessFrame(_ sample: PoseSample, quality: PerformanceController.QualityLevel) -> Bool {
         switch quality {
         case .low, .minimal:
             return false

--- a/Sources/WorkoutCounterCameraSample/CameraWorkoutController.swift
+++ b/Sources/WorkoutCounterCameraSample/CameraWorkoutController.swift
@@ -1,0 +1,65 @@
+#if canImport(AVFoundation) && canImport(Vision) && canImport(UIKit)
+import UIKit
+import AVFoundation
+import Vision
+import WorkoutCounter
+
+/// Sample controller that streams camera frames to Vision and WorkoutCounter.
+public final class CameraWorkoutController: NSObject {
+    private let session = AVCaptureSession()
+    private let visionQueue = DispatchQueue(label: "vision.queue")
+    private let engine = StreamingWorkoutEngine()
+    private let performance = PerformanceController()
+
+    public override init() {
+        super.init()
+        configureSession()
+    }
+
+    private func configureSession() {
+        session.sessionPreset = .high
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device) else { return }
+        session.addInput(input)
+        let output = AVCaptureVideoDataOutput()
+        output.setSampleBufferDelegate(self, queue: DispatchQueue(label: "capture.queue"))
+        session.addOutput(output)
+    }
+
+    public func start() { session.startRunning() }
+    public func stop() { session.stopRunning() }
+
+    private func handleObservation(_ obs: VNHumanBodyPoseObservation) {
+        let pose = PoseObservation(visionObservation: obs)
+        let sample = poseSample(from: pose, at: CFAbsoluteTimeGetCurrent())
+        _ = engine.processFrame(sample)
+    }
+}
+
+extension CameraWorkoutController: AVCaptureVideoDataOutputSampleBufferDelegate {
+    public func captureOutput(_ output: AVCaptureOutput,
+                              didOutput sampleBuffer: CMSampleBuffer,
+                              from connection: AVCaptureConnection) {
+        visionQueue.async { [weak self] in
+            guard let self = self else { return }
+            let start = CFAbsoluteTimeGetCurrent()
+            defer {
+                let elapsed = CFAbsoluteTimeGetCurrent() - start
+                self.performance.recordFrameTime(elapsed)
+                print("Frame time: \(elapsed)")
+            }
+            guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+            let request = VNDetectHumanBodyPoseRequest()
+            let handler = VNImageRequestHandler(cvPixelBuffer: buffer, options: [:])
+            do {
+                try handler.perform([request])
+                if let result = request.results?.first as? VNHumanBodyPoseObservation {
+                    self.handleObservation(result)
+                }
+            } catch {
+                print("Vision error: \(error)")
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose StreamingWorkoutEngine and PerformanceController as public APIs
- add WorkoutCounterCameraSample target showing how to process AVCaptureSession frames
- update Package.swift with a new sample library

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6840458693408332a702dd2382b93c24