### PR TITLE
Introduce PoseFrame API

### DIFF
--- a/Sources/WorkoutCounter/PoseFrame.swift
+++ b/Sources/WorkoutCounter/PoseFrame.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Time-stamped pose information for live processing.
+public struct PoseFrame: Sendable {
+    /// Capture time of the frame in seconds.
+    public let time: TimeInterval
+    /// Mapping of body joints detected in the frame.
+    public let joints: [PoseObservation.JointName: PoseObservation.JointPoint]
+
+    public init(time: TimeInterval, joints: [PoseObservation.JointName: PoseObservation.JointPoint]) {
+        self.time = time
+        self.joints = joints
+    }
+}
+
+public extension PoseFrame {
+    /// Initialize from a ``PoseObservation`` and timestamp.
+    init(time: TimeInterval, observation: PoseObservation) {
+        self.init(time: time, joints: observation.joints)
+    }
+
+    /// Converts the frame into a legacy ``PoseSample`` value.
+    /// - Returns: ``PoseSample`` using the right elbow angle metric.
+    func toPoseSample() -> PoseSample {
+        poseSample(from: PoseObservation(joints: joints), at: time)
+    }
+}

--- a/Sources/WorkoutCounter/PoseObservation.swift
+++ b/Sources/WorkoutCounter/PoseObservation.swift
@@ -58,7 +58,7 @@ import Vision
 /// Platform-agnostic representation of a body pose.
 public struct PoseObservation {
     /// Supported joint identifiers matching Vision's joint names.
-    public enum JointName: String {
+    public enum JointName: String, Sendable {
         case root
         case neck
         case nose
@@ -81,7 +81,7 @@ public struct PoseObservation {
     }
 
     /// Location and confidence for a body joint.
-    public struct JointPoint {
+    public struct JointPoint: Sendable {
         public let x: Double
         public let y: Double
         public let confidence: Double

--- a/Sources/WorkoutCounter/RepetitionDetector.swift
+++ b/Sources/WorkoutCounter/RepetitionDetector.swift
@@ -20,9 +20,9 @@ public final class RepetitionDetector {
         self.productionDetector = ProductionRepetitionDetector()
     }
 
-    /// Processes a pose sample and returns a completed repetition if available.
-    public func process(sample: PoseSample) -> RepetitionLog? {
-        let result = productionDetector.processFrame(sample)
+    /// Processes a pose frame and returns a completed repetition if available.
+    public func process(frame: PoseFrame) -> RepetitionLog? {
+        let result = productionDetector.processFrame(frame)
         if case .repetitionCompleted(let log) = result {
             return log
         }

--- a/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
+++ b/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
@@ -23,17 +23,17 @@ public final class StreamingWorkoutEngine {
 
   public enum FrameSkipReason { case performanceOptimization }
 
-    public func processFrame(_ sample: PoseSample) -> WorkoutUpdate {
+    public func processFrame(_ frame: PoseFrame) -> WorkoutUpdate {
         let start = CFAbsoluteTimeGetCurrent()
 
         let quality = performanceController.getOptimalQuality()
         detector.adaptToPerformanceLevel(quality)
 
-        guard shouldProcessFrame(sample, quality: quality) else {
+        guard shouldProcessFrame(frame, quality: quality) else {
             return .frameSkipped(reason: .performanceOptimization)
         }
 
-        let result = detector.processFrame(sample)
+        let result = detector.processFrame(frame)
         let elapsed = CFAbsoluteTimeGetCurrent() - start
         performanceController.recordFrameTime(elapsed)
 
@@ -57,7 +57,7 @@ public final class StreamingWorkoutEngine {
         }
     }
 
-    public func shouldProcessFrame(_ sample: PoseSample, quality: PerformanceController.QualityLevel) -> Bool {
+    public func shouldProcessFrame(_ sample: PoseFrame, quality: PerformanceController.QualityLevel) -> Bool {
         switch quality {
         case .low, .minimal:
             return false

--- a/Tests/WorkoutCounterTests/PerformanceBenchmarks.swift
+++ b/Tests/WorkoutCounterTests/PerformanceBenchmarks.swift
@@ -5,20 +5,20 @@ import Foundation
 @Test
 func realTimePerformance() async throws {
     let detector = ProductionRepetitionDetector()
-    let samples = generateHighFrequencyStream(sampleCount: 1000)
+    let samples = generateHighFrequencyFrameStream(sampleCount: 1000)
     for s in samples { _ = detector.processFrame(s) }
 }
 
 @Test
 func memoryPerformance() async throws {
     let detector = ProductionRepetitionDetector()
-    let samples = generateLongStream(sampleCount: 1000)
+    let samples = generateLongFrameStream(sampleCount: 1000)
     for s in samples { _ = detector.processFrame(s) }
 }
 
 @Test
 func adaptiveQualityPerformance() async throws {
     let engine = StreamingWorkoutEngine(exercisePattern: nil)
-    let samples = generateHighComplexityStream()
+    let samples = generateHighComplexityFrameStream()
     for s in samples { _ = engine.processFrame(s) }
 }


### PR DESCRIPTION
## Summary
- add `PoseFrame` struct with conversion helpers
- adapt streaming detectors and engine to use `PoseFrame`
- provide frame-based mock data generators and convert to old `PoseSample`
- update unit tests for new struct while keeping legacy paths
- document new usage in README

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684046a4bb788332ae1c2c7a4d35f700