### PR TITLE
Add Vision performance tracking

### DIFF
--- a/Sources/WorkoutCounter/ProductionRepetitionDetector.swift
+++ b/Sources/WorkoutCounter/ProductionRepetitionDetector.swift
@@ -22,6 +22,7 @@ final class ProductionRepetitionDetector {
     private var confidence = ConfidenceAccumulator()
     private let validator = TemporalValidator()
     private var processingTimes = CircularBuffer<TimeInterval>(capacity: 60)
+    private var visionTimes = CircularBuffer<TimeInterval>(capacity: 60)
 
     init(pattern: ExercisePattern? = nil) {
         self.exercisePattern = pattern
@@ -114,12 +115,20 @@ final class ProductionRepetitionDetector {
     func getPerformanceMetrics() -> DetectorPerformanceMetrics {
         let times = processingTimes.toArray()
         let avg = times.isEmpty ? 0 : times.reduce(0, +) / Double(times.count)
+        let vision = visionTimes.toArray()
+        let visionAvg = vision.isEmpty ? 0 : vision.reduce(0, +) / Double(vision.count)
         return DetectorPerformanceMetrics(
             averageProcessingTime: avg,
+            averageVisionProcessingTime: visionAvg,
             memoryUsage: 0,
             confidenceAccuracy: 1,
             falsePositiveRate: 0
         )
+    }
+
+    /// Records the time taken by Vision processing for a frame.
+    func recordVisionProcessingTime(_ duration: TimeInterval) {
+        visionTimes.append(duration)
     }
 
     /// Adjusts detection complexity according to a quality level.
@@ -177,6 +186,7 @@ final class ProductionRepetitionDetector {
 /// Basic metrics describing detector performance.
 struct DetectorPerformanceMetrics {
     let averageProcessingTime: TimeInterval
+    let averageVisionProcessingTime: TimeInterval
     let memoryUsage: Int
     let confidenceAccuracy: Float
     let falsePositiveRate: Float

--- a/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
+++ b/Sources/WorkoutCounter/StreamingWorkoutEngine.swift
@@ -65,4 +65,14 @@ public final class StreamingWorkoutEngine {
             return true
         }
     }
+
+    /// Records Vision processing duration for performance metrics.
+    public func recordVisionProcessingTime(_ duration: TimeInterval) {
+        detector.recordVisionProcessingTime(duration)
+    }
+
+    /// Retrieves aggregated detector performance metrics.
+    func getDetectorMetrics() -> DetectorPerformanceMetrics {
+        return detector.getPerformanceMetrics()
+    }
 }


### PR DESCRIPTION
## Summary
- extend `DetectorPerformanceMetrics` with average vision processing time
- expose methods on `StreamingWorkoutEngine` for Vision timing
- adjust sample iOS controller to log vision and frame duration and skip frames using `PerformanceController`
- add unit test to feed stub Vision data through the engine

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_684048c9ec1c8332b7d6de83d2bf687f